### PR TITLE
Fix of entry-point script which makes connector to fail

### DIFF
--- a/kafka-connect-base/entry-point
+++ b/kafka-connect-base/entry-point
@@ -31,9 +31,6 @@ fi
 if [ ! -f /etc/kafka-connect/connector.properties ]; then
     echo "Failed to find /etc/kafka-connect/connector.properties"
     exit 1
-elif [ ! -f /etc/kafka-connect/secrets.properties ]; then
-    echo "Failed to find /etc/kafka-connect/secrets.properties"
-    exit 1
 elif [ ! -f /etc/kafka-connect/kafka-connect.properties ]; then
     echo "Failed to find /etc/kafka-connect/kafka-connect.properties"
     exit 1


### PR DESCRIPTION
The issue is that if you don't provide any secret data the
`secrets.properties` will never be created. So the `entry-point` script
checks for the file which doesn't exist and exits the script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/stream-reactor-dockers/11)
<!-- Reviewable:end -->
